### PR TITLE
Fix post for EMNLP papers

### DIFF
--- a/content/post/emnlp2025/index.md
+++ b/content/post/emnlp2025/index.md
@@ -30,8 +30,8 @@ projects: []
 
 Four papers from researchers in the TRAILS project have been accepted as Main and Findings papers at the [2025 Conference on Empirical Methods in Natural Language Processing (EMNLP 2025)](https://2025.emnlp.org/). EMNLP will take place November 4-9 in Suzhou, China. The first paper, titled "Multilingual Datasets for Custom Input Extraction and Explanation Requests Parsing in Conversational XAI Systems", introduces two multilingual datasets in the context of Conversational XAI systems, one for intent recognition, and one for slot filling / input extraction. The second paper presents the first comprehensive evaluation of large language models (LLMs) for multilingual previously fact-checked claim detection. The third paper systematically evaluates the performance of various prompt-based synthetic generation strategies for low-resource languages. Using three NLP tasks and four open-source LLMs, the paper also assesses downstream model performance on generated versus gold-standard data. Finally, the fourth paper investigates political bias in LLMs through exchanging words in minimal sentence pairs with euphemisms or dysphemisms in German claims. 
 
-{{< cite page="/publication/oguz-etal-2025-vykopal-large" view="4" >}}
-{{< cite page="/publication/wang-etal-2025-anikina-rigorous" view="4" >}}
+{{< cite page="/publication/vykopal-etal-2025-large" view="4" >}}
 {{< cite page="/publication/wang-etal-2025-multilingual" view="4" >}}
-{{< cite page="/publication/jakob-etal-2025-polbix" view="4" >}}
+{{< cite page="/publication/anikina-etal-2025-rigorous" view="4" >}}
+{{< cite page="/publication/jakob-2025-polbix" view="4" >}}
 

--- a/content/publication/vykopal-etal-2025-large/cite.bib
+++ b/content/publication/vykopal-etal-2025-large/cite.bib
@@ -1,4 +1,4 @@
-@inproceedings{vykopal-etal-2025-multilingual,
+@inproceedings{vykopal-etal-2025-large,
   title={Large Language Models for Multilingual Previously Fact-Checked Claim Detection},
   author={Vykopal, Ivan and Pikuliak, Matus and Ostermann, Simon and Anikina, Tatiana and Gregor, Michal and Simko, Marian},
   booktitle={Findings of the Conference on Empirical Methods in Natural Language Processing (EMNLP 2025)},


### PR DESCRIPTION
Currently, the EMNLP-25 post is not being shown on the TRAILS website. I think this happens when the paper references do not match the corresponding files/folders (they were a bit mixed with the references from the previous post, e.g. `/publication/oguz-etal-2025-vykopal-large` instead of `/publication/vykopal-etal-2025-large`).