### PR TITLE
Add LowResNLP paper on fact-checking in English & Telugu

### DIFF
--- a/content/publication/chikkala-etal-2025-automatic/cite.bib
+++ b/content/publication/chikkala-etal-2025-automatic/cite.bib
@@ -1,0 +1,7 @@
+@inproceedings{chikkala-etal-2025-automatic,
+  title={Automatic Fact-checking in English and Telugu},
+  author={Chikkala, Ravi Kiran and Anikina, Tatiana and Skachkova, Natalia and Vykopal, Ivan and Agerri, Rodrigo and van Genabith, Josef},
+  booktitle={Proceedings of the Workshop on Advancing NLP for Low-Resource Languages (RANLP 2025)},
+  year={2025},
+  url = "https://lrlnlp.github.io/website/",
+}

--- a/content/publication/chikkala-etal-2025-automatic/index.md
+++ b/content/publication/chikkala-etal-2025-automatic/index.md
@@ -1,0 +1,20 @@
+---
+title: 'Automatic Fact-checking in English and Telugu'
+authors:
+- Ravi Kiran Chikkala
+- Tatiana Anikina
+- Natalia Skachkova
+- Ivan Vykopal
+- Rodrigo Agerri
+- Josef van Genabith
+date: '2025-09-11'
+publication_types:
+- paper-conference
+publication: '*Proceedings of the Workshop on Advancing NLP for Low-Resource Languages: RANLP 2025*'
+publication_short: LowResNLP 2025
+abstract: "False information poses a significant global challenge, and manually verifying claims is a time-consuming and resource-intensive process. In this research paper, we experiment with different approaches to investigate the effectiveness of large language models (LLMs) in classifying factual claims by their veracity and generating justifications in English and Telugu. The key contributions of this work include the creation of a bilingual English-Telugu dataset and the benchmarking of different veracity classification approaches based on LLMs."
+url_pdf: https://arxiv.org/abs/2509.26415
+links:
+- name: URL
+  url: https://arxiv.org/abs/2509.26415
+---


### PR DESCRIPTION
This PR adds references to the paper on Fact-checking in English and Telugu that was accepted to the LowResNLP workshop at RANLP. Note that I could not find the link to the official proceedings yet but I guess they will be published soon and we can update the link later. This paper also acknowledges TRAILS.

Actually, there was another student paper supervised by Tanja and me that was accepted to the GlobalNLP workshop at RANLP (_What Language(s) Does Aya-23 Think In? How Multilinguality Affects Internal Language Representations_) but I'm afraid that we cannot mention it here bc we forgot to add the acknowledgements section.